### PR TITLE
Null collection elements and export form

### DIFF
--- a/Visualizer/App.config
+++ b/Visualizer/App.config
@@ -36,6 +36,9 @@
             <setting name="FindString" serializeAs="String">
                 <value />
             </setting>
+            <setting name="ExportProfile" serializeAs="String">
+                <value />
+            </setting>            
         </AgGateway.ADAPT.Visualizer.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Visualizer/Model.cs
+++ b/Visualizer/Model.cs
@@ -386,10 +386,17 @@ namespace AgGateway.ADAPT.Visualizer
 
                 foreach (var child in collection)
                 {
-                    var childObject = child;
-                    var type = CheckType(ref childObject, childObject.GetType());
-                    //170623 MSp var node = new TreeNode(type.Name)
-                    string nodeText = _extendNodeText(type.Name, childObject, type);    //170623 MSp 
+                    string nodeText;            //190502 MSp
+                    if (child == null)          //190502 MSp
+                    {                           //190502 MSp
+                         nodeText = "#null#";   //190502 MSp
+                    }                           //190502 MSp
+                    else                        //190502 MSp
+                    {                           //190502 MSp
+                        var childObject = child;
+                        var type = CheckType(ref childObject, childObject.GetType());
+                        nodeText = _extendNodeText(type.Name, childObject, type);    
+                    }                           //190429 MS
                     var node = new TreeNode(nodeText)                                   //170623 MSp 
                     {
                         Tag = new ObjectWithIndex(_admIndex, child)

--- a/Visualizer/Properties/Settings.Designer.cs
+++ b/Visualizer/Properties/Settings.Designer.cs
@@ -62,6 +62,18 @@ namespace AgGateway.ADAPT.Visualizer.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ExportProfile {
+            get {
+                return ((string)(this["ExportProfile"]));
+            }
+            set {
+                this["ExportProfile"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string InitializeString {
             get {
                 return ((string)(this["InitializeString"]));

--- a/Visualizer/Properties/Settings.settings
+++ b/Visualizer/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="ImportPathHistory" Type="System.Windows.Forms.AutoCompleteStringCollection" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ExportProfile" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>    
   </Settings>
 </SettingsFile>

--- a/Visualizer/UI/ExportForm.cs
+++ b/Visualizer/UI/ExportForm.cs
@@ -19,9 +19,17 @@ namespace AgGateway.ADAPT.Visualizer.UI
             if (_model.AvailablePlugins().Any())
                 _loadedPluginsListBox.DataSource = _model.AvailablePlugins();
 
+            string lastProfile = Settings.Default.ExportProfile;
             foreach (var applicationDataModel in _model.ApplicationDataModels.OrderBy(x => x.Catalog.Description))
             {
                 cardProfileSelection.Items.Add(applicationDataModel.Catalog.Description);
+                if ((!string.IsNullOrEmpty(lastProfile)) && (applicationDataModel.Catalog.Description.Equals(lastProfile, StringComparison.CurrentCultureIgnoreCase))) {
+                    cardProfileSelection.SelectedIndex = cardProfileSelection.Items.Count - 1;
+                }
+            }
+            if ((cardProfileSelection.Items.Count > 0) && (cardProfileSelection.SelectedIndex < 0))
+            {
+                cardProfileSelection.SelectedIndex = 0;               
             }
         }
 
@@ -102,6 +110,7 @@ namespace AgGateway.ADAPT.Visualizer.UI
             Settings.Default.PluginPath = _pluginPathTextBox.Text;
             Settings.Default.InitializeString = _initializeStringTextBox.Text;
             Settings.Default.ExportPath = _exportPathTextBox.Text;
+            Settings.Default.ExportProfile = cardProfileSelection.Text; 
             Settings.Default.Save();
         }
 


### PR DESCRIPTION
- No exceptions if null collection elements are encountered.
- On export the last profile is restored. If the last profile name cannot be found, the first profile is selected.