### PR TITLE
Allow user to limit loaded data for a more responsive UI; save and restore window settings; reduce redundant work; accelerate rendering

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf

--- a/Visualizer.sln
+++ b/Visualizer.sln
@@ -1,9 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Visualizer", "Visualizer\Visualizer.csproj", "{308B8C5A-715D-4F80-8EA4-C4CD9FBCB970}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34024.191
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Visualizer", "Visualizer\Visualizer.csproj", "{308B8C5A-715D-4F80-8EA4-C4CD9FBCB970}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VisualizerTests", "VisualizerTests\VisualizerTests.csproj", "{C0A52DC9-DE05-4897-A38A-709472CFE0D6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E8FAB789-F954-4140-95BE-52493C50469F}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,5 +29,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3F33EB9E-9293-42E0-9DA0-4F4FB40E53B0}
 	EndGlobalSection
 EndGlobal

--- a/Visualizer/App.config
+++ b/Visualizer/App.config
@@ -20,7 +20,7 @@
                 <value>c:\export</value>
             </setting>
             <setting name="InitializeString" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="AutoLoadPlugins" serializeAs="String">
                 <value>True</value>
@@ -31,24 +31,58 @@
             <setting name="ExportProfile" serializeAs="String">
                 <value />
             </setting>
+            <setting name="ExportPlugin" serializeAs="String">
+                <value />
+            </setting>
             <setting name="ImportProperties" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                         <string>TestKey;TestValue</string>
                     </ArrayOfString>
                 </value>
             </setting>
             <setting name="ExportProperties" serializeAs="Xml">
                 <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                    <ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                         <string>TestKey;TestValue</string>
                     </ArrayOfString>
                 </value>
             </setting>
-            <setting name="ExportPlugin" serializeAs="String">
-                <value />
+            <setting name="ShowLimitDataUI" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="RememberWindowSettings" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="Maximized" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="UnmaximizedSize" serializeAs="String">
+                <value>0, 0</value>
+            </setting>
+            <setting name="UnmaximizedLocation" serializeAs="String">
+                <value>0, 0</value>
+            </setting>
+            <setting name="AutoScaleWidth" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="AutoScaleHeight" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="SplitterDistanceMap" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="SplitterDistanceViewer" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="LimitData" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="MaxRows" serializeAs="String">
+                <value>100</value>
+            </setting>
+            <setting name="MaxColumns" serializeAs="String">
+                <value>50</value>
             </setting>
         </AgGateway.ADAPT.Visualizer.Properties.Settings>
     </userSettings>

--- a/Visualizer/DrawingUtil.cs
+++ b/Visualizer/DrawingUtil.cs
@@ -10,7 +10,8 @@ using System.Drawing.Drawing2D;
   *
   * Contributors:
   *    Tarak Reddy - initial implementation
-  *    Joseph Ross - Made Changes to Account for mapping multiple guidence patterns with the same context
+  *    Joseph Ross - Made Changes to Account for mapping multiple guidance patterns with the same context
+  *    Andrew Vardeman - Plugged GDI+ memory leaks due to un-disposed pens
   *******************************************************************************/
 
 using System.Linq;
@@ -39,48 +40,19 @@ namespace AgGateway.ADAPT.Visualizer
         public Graphics Graphics { get; private set; }
 
         //Default values
-        public static Pen B_Black //WorkingData is not numeric
-        {
-            get { return new Pen(Color.Black, 2); }
-        }
-        public static Pen C_DarkMagenta //Non-zero values
-        {
-            get { return new Pen(Color.DarkMagenta, 2); }
-        }
-        public static Pen E_Red //Zero values or minimum values
-        {
-            get { return new Pen(Color.Red, 2); }
-        }
+        public static Pen B_Black { get; } = new Pen(Color.Black, 2); //WorkingData is not numeric
+        public static Pen C_DarkMagenta { get; } = new Pen(Color.DarkMagenta, 2); //Non-zero values
+        public static Pen E_Red { get; } = new Pen(Color.Red, 2); //Zero values or minimum values
 
         //Range 7 levels
-        public static Pen F_DarkOrange
-        {
-            get { return new Pen(Color.DarkOrange, 2); }
-        }
-        public static Pen G_Gold
-        {
-            get { return new Pen(Color.Gold, 2); }
-        }
-        public static Pen H_YellowGreen
-        {
-            get { return new Pen(Color.YellowGreen, 2); }
-        }
-        public static Pen I_LawnGreen
-        {
-            get { return new Pen(Color.LawnGreen, 2); }
-        }
-        public static Pen J_LimeGreen
-        {
-            get { return new Pen(Color.LimeGreen, 2); }
-        }
-        public static Pen K_ForestGreen
-        {
-            get { return new Pen(Color.ForestGreen, 2); }
-        }
-        public static Pen L_DarkGreen
-        {
-            get { return new Pen(Color.DarkGreen, 2); }
-        }
+        public static Pen F_DarkOrange { get; } = new Pen(Color.DarkOrange, 2);
+        public static Pen G_Gold { get; } = new Pen(Color.Gold, 2);
+        public static Pen H_YellowGreen { get; } = new Pen(Color.YellowGreen, 2);
+        public static Pen I_LawnGreen { get; } = new Pen(Color.LawnGreen, 2);
+        public static Pen J_LimeGreen { get; } = new Pen(Color.LimeGreen, 2);
+        public static Pen K_ForestGreen { get; } = new Pen(Color.ForestGreen, 2);
+        public static Pen L_DarkGreen { get; } = new Pen(Color.DarkGreen, 2);
+
 
         public double GetDelta()
         {

--- a/Visualizer/Model.cs
+++ b/Visualizer/Model.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Data;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -532,30 +533,31 @@ namespace AgGateway.ADAPT.Visualizer
             }
         }
 
-        public void WriteCsvFile(string fileName, DataGridView dataGridView)
+        public void WriteCsvFile(string fileName, DataTable dataTable)
         {
+            int columnCount = dataTable.Columns.Count;
             using (var streamWriter = new StreamWriter(fileName))
             {
                 var sb = new StringBuilder();
 
-                for (int i = 0; i < dataGridView.Columns.Count; i++)
+                for (int i = 0; i < columnCount; i++)
                 {
                     if (i != 0)
                         sb.Append(",");
 
-                    sb.Append(dataGridView.Columns[i].Name);
+                    sb.Append(dataTable.Columns[i].ColumnName);
                 }
                 streamWriter.WriteLine(sb.ToString());
 
-                foreach (DataGridViewRow row in dataGridView.Rows)
+                foreach (DataRow row in dataTable.Rows)
                 {
                     sb.Clear();
-                    for (int j = 0; j < dataGridView.Columns.Count; j++)
+                    for (int j = 0; j < columnCount; j++)
                     {
                         if (j != 0)
                             sb.Append(",");
 
-                        sb.Append(row.Cells[j].Value);
+                        sb.Append(row[j]);
                     }
                     streamWriter.WriteLine(sb.ToString());
                 }

--- a/Visualizer/Model.cs
+++ b/Visualizer/Model.cs
@@ -545,10 +545,11 @@ namespace AgGateway.ADAPT.Visualizer
 
                     sb.Append(dataGridView.Columns[i].Name);
                 }
+                streamWriter.WriteLine(sb.ToString());
 
                 foreach (DataGridViewRow row in dataGridView.Rows)
                 {
-                    sb.Append("\n");
+                    sb.Clear();
                     for (int j = 0; j < dataGridView.Columns.Count; j++)
                     {
                         if (j != 0)
@@ -556,9 +557,9 @@ namespace AgGateway.ADAPT.Visualizer
 
                         sb.Append(row.Cells[j].Value);
                     }
+                    streamWriter.WriteLine(sb.ToString());
                 }
 
-                streamWriter.WriteLine(sb.ToString());
                 streamWriter.Flush();
                 streamWriter.Close();
             }

--- a/Visualizer/OperationDataProcessor.cs
+++ b/Visualizer/OperationDataProcessor.cs
@@ -24,6 +24,7 @@ namespace AgGateway.ADAPT.Visualizer
     public class OperationDataProcessor
     {
         private DataTable? _dataTable;
+        private int _firstDynamicColumnIndex;
         private OperationData? _lastOperationData;
         private List<SpatialRecord>? _lastSpatialRecords;
         private bool _lastUseMaxCols;
@@ -47,6 +48,7 @@ namespace AgGateway.ADAPT.Visualizer
                 _dataTable.Columns.Add(new DataColumn("Longitude")); //X
                 _dataTable.Columns.Add(new DataColumn("Elevation")); //Z
                 _dataTable.Columns.Add(new DataColumn("TimeStamp")); //time
+                _firstDynamicColumnIndex = _dataTable.Columns.Count;
 
                 if (spatialRecords.Any())
                 {
@@ -99,30 +101,30 @@ namespace AgGateway.ADAPT.Visualizer
 
         private void CreateColumns(Dictionary<int, IEnumerable<WorkingData>> workingDataDictionary)
         {
-            foreach (var kvp in workingDataDictionary)
+            for (int depth = 0; depth < workingDataDictionary.Count; depth++)
             {
-                foreach (var workingData in kvp.Value)
+                foreach (var workingData in workingDataDictionary[depth])
                 {
-                    _dataTable.Columns.Add(GetColumnName(workingData, kvp.Key));
+                    _dataTable!.Columns.Add(GetColumnName(workingData, depth));
                 }
             }
         }
 
         private void CreateRow(Dictionary<int, IEnumerable<WorkingData>> workingDataDictionary, SpatialRecord spatialRecord, int index)
         {
-            var dataRow = _dataTable.NewRow();
+            var dataRow = _dataTable!.NewRow();
 
-            foreach(var key in workingDataDictionary.Keys)
+            int colIdx = _firstDynamicColumnIndex;
+            for (int depth = 0; depth < workingDataDictionary.Count; depth++)
             {
-                var depth = key;
-
-                foreach (var workingData in workingDataDictionary[key])
+                foreach (var workingData in workingDataDictionary[depth])
                 {
                     if (workingData as NumericWorkingData != null)
-                        CreateNumericMeterCell(spatialRecord, workingData, depth, dataRow);
+                        CreateNumericMeterCell(spatialRecord, workingData, depth, dataRow, colIdx);
 
                     if (workingData as EnumeratedWorkingData != null)
-                        CreateEnumeratedMeterCell(spatialRecord, workingData, depth, dataRow);
+                        CreateEnumeratedMeterCell(spatialRecord, workingData, depth, dataRow, colIdx);
+                    colIdx++;
                 }
             }
 
@@ -142,21 +144,21 @@ namespace AgGateway.ADAPT.Visualizer
             _dataTable.Rows.Add(dataRow);
         }
 
-        private static void CreateEnumeratedMeterCell(SpatialRecord spatialRecord, WorkingData workingData, int depth, DataRow dataRow)
+        private static void CreateEnumeratedMeterCell(SpatialRecord spatialRecord, WorkingData workingData, int depth, DataRow dataRow, int columnIndex)
         {
             var enumeratedValue = spatialRecord.GetMeterValue(workingData) as EnumeratedValue;
 
-            dataRow[GetColumnName(workingData, depth)] = enumeratedValue != null && enumeratedValue.Value != null ? enumeratedValue.Value.Value : "";
+            dataRow[columnIndex] = enumeratedValue != null && enumeratedValue.Value != null ? enumeratedValue.Value.Value : "";
         }
 
-        private static void CreateNumericMeterCell(SpatialRecord spatialRecord, WorkingData workingData, int depth, DataRow dataRow)
+        private static void CreateNumericMeterCell(SpatialRecord spatialRecord, WorkingData workingData, int depth, DataRow dataRow, int columnIndex)
         {
             var numericRepresentationValue = spatialRecord.GetMeterValue(workingData) as NumericRepresentationValue;
             var value = numericRepresentationValue != null
                 ? numericRepresentationValue.Value.Value.ToString(CultureInfo.InvariantCulture)
                 : "";
 
-            dataRow[GetColumnName(workingData, depth)] = value;
+            dataRow[columnIndex] = value;
         }
 
         private void UpdateColumnNamesWithUom(Dictionary<int, IEnumerable<WorkingData>> workingDatas, List<SpatialRecord> spatialRecords)

--- a/Visualizer/Properties/Settings.Designer.cs
+++ b/Visualizer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AgGateway.ADAPT.Visualizer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -120,8 +120,20 @@ namespace AgGateway.ADAPT.Visualizer.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
-            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <s" +
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ExportPlugin {
+            get {
+                return ((string)(this["ExportPlugin"]));
+            }
+            set {
+                this["ExportPlugin"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsd=\"http://www.w3." +
+            "org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <s" +
             "tring>TestKey;TestValue</string>\r\n</ArrayOfString>")]
         public global::System.Collections.Specialized.StringCollection ImportProperties {
             get {
@@ -134,8 +146,8 @@ namespace AgGateway.ADAPT.Visualizer.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsi=\"http://www.w3." +
-            "org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <s" +
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<ArrayOfString xmlns:xsd=\"http://www.w3." +
+            "org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n  <s" +
             "tring>TestKey;TestValue</string>\r\n</ArrayOfString>")]
         public global::System.Collections.Specialized.StringCollection ExportProperties {
             get {
@@ -148,13 +160,145 @@ namespace AgGateway.ADAPT.Visualizer.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string ExportPlugin {
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowLimitDataUI {
             get {
-                return ((string)(this["ExportPlugin"]));
+                return ((bool)(this["ShowLimitDataUI"]));
             }
             set {
-                this["ExportPlugin"] = value;
+                this["ShowLimitDataUI"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RememberWindowSettings {
+            get {
+                return ((bool)(this["RememberWindowSettings"]));
+            }
+            set {
+                this["RememberWindowSettings"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Maximized {
+            get {
+                return ((bool)(this["Maximized"]));
+            }
+            set {
+                this["Maximized"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0, 0")]
+        public global::System.Drawing.Size UnmaximizedSize {
+            get {
+                return ((global::System.Drawing.Size)(this["UnmaximizedSize"]));
+            }
+            set {
+                this["UnmaximizedSize"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0, 0")]
+        public global::System.Drawing.Point UnmaximizedLocation {
+            get {
+                return ((global::System.Drawing.Point)(this["UnmaximizedLocation"]));
+            }
+            set {
+                this["UnmaximizedLocation"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public float AutoScaleWidth {
+            get {
+                return ((float)(this["AutoScaleWidth"]));
+            }
+            set {
+                this["AutoScaleWidth"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public float AutoScaleHeight {
+            get {
+                return ((float)(this["AutoScaleHeight"]));
+            }
+            set {
+                this["AutoScaleHeight"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int SplitterDistanceMap {
+            get {
+                return ((int)(this["SplitterDistanceMap"]));
+            }
+            set {
+                this["SplitterDistanceMap"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int SplitterDistanceViewer {
+            get {
+                return ((int)(this["SplitterDistanceViewer"]));
+            }
+            set {
+                this["SplitterDistanceViewer"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LimitData {
+            get {
+                return ((bool)(this["LimitData"]));
+            }
+            set {
+                this["LimitData"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("100")]
+        public int MaxRows {
+            get {
+                return ((int)(this["MaxRows"]));
+            }
+            set {
+                this["MaxRows"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public int MaxColumns {
+            get {
+                return ((int)(this["MaxColumns"]));
+            }
+            set {
+                this["MaxColumns"] = value;
             }
         }
     }

--- a/Visualizer/Properties/Settings.settings
+++ b/Visualizer/Properties/Settings.settings
@@ -26,20 +26,56 @@
     <Setting Name="ExportProfile" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ExportPlugin" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
     <Setting Name="ImportProperties" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
   &lt;string&gt;TestKey;TestValue&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
     </Setting>
     <Setting Name="ExportProperties" Type="System.Collections.Specialized.StringCollection" Scope="User">
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
-&lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"&gt;
+&lt;ArrayOfString xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"&gt;
   &lt;string&gt;TestKey;TestValue&lt;/string&gt;
 &lt;/ArrayOfString&gt;</Value>
     </Setting>
-    <Setting Name="ExportPlugin" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
+    <Setting Name="ShowLimitDataUI" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="RememberWindowSettings" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="Maximized" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="UnmaximizedSize" Type="System.Drawing.Size" Scope="User">
+      <Value Profile="(Default)">0, 0</Value>
+    </Setting>
+    <Setting Name="UnmaximizedLocation" Type="System.Drawing.Point" Scope="User">
+      <Value Profile="(Default)">0, 0</Value>
+    </Setting>
+    <Setting Name="AutoScaleWidth" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="AutoScaleHeight" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="SplitterDistanceMap" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="SplitterDistanceViewer" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="LimitData" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="MaxRows" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">100</Value>
+    </Setting>
+    <Setting Name="MaxColumns" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">50</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/Visualizer/UI/MainForm.Designer.cs
+++ b/Visualizer/UI/MainForm.Designer.cs
@@ -188,11 +188,11 @@
             // 
             _dataGridViewRawData.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             _dataGridViewRawData.Dock = DockStyle.Fill;
-            _dataGridViewRawData.Location = new Point(0, 0);
-            _dataGridViewRawData.Margin = new Padding(0);
+            _dataGridViewRawData.Location = new Point(4, 5);
+            _dataGridViewRawData.Margin = new Padding(4, 5, 4, 5);
             _dataGridViewRawData.Name = "_dataGridViewRawData";
             _dataGridViewRawData.RowHeadersWidth = 62;
-            _dataGridViewRawData.Size = new Size(654, 329);
+            _dataGridViewRawData.Size = new Size(646, 321);
             _dataGridViewRawData.TabIndex = 0;
             _dataGridViewRawData.ColumnAdded += _dataGridViewRawData_ColumnAdded;
             _dataGridViewRawData.Paint += _dataGridViewRawData_Paint;
@@ -200,8 +200,8 @@
             // _buttonExportRawData
             // 
             _buttonExportRawData.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            _buttonExportRawData.Location = new Point(529, 335);
-            _buttonExportRawData.Margin = new Padding(6);
+            _buttonExportRawData.Location = new Point(531, 336);
+            _buttonExportRawData.Margin = new Padding(4, 5, 4, 5);
             _buttonExportRawData.Name = "_buttonExportRawData";
             _buttonExportRawData.Size = new Size(119, 35);
             _buttonExportRawData.TabIndex = 1;

--- a/Visualizer/UI/MainForm.Designer.cs
+++ b/Visualizer/UI/MainForm.Designer.cs
@@ -128,7 +128,7 @@
             _splitContainerMap.Panel2.Controls.Add(_dataGridViewTotals);
             _splitContainerMap.Panel2.Controls.Add(_labelTotals);
             _splitContainerMap.Size = new Size(662, 682);
-            _splitContainerMap.SplitterDistance = 453;
+            _splitContainerMap.SplitterDistance = 564;
             _splitContainerMap.SplitterWidth = 6;
             _splitContainerMap.TabIndex = 0;
             _splitContainerMap.SplitterMoved += _splitContainerMap_SplitterMoved;
@@ -142,7 +142,7 @@
             _tabControlViewer.Margin = new Padding(4, 5, 4, 5);
             _tabControlViewer.Name = "_tabControlViewer";
             _tabControlViewer.SelectedIndex = 0;
-            _tabControlViewer.Size = new Size(662, 409);
+            _tabControlViewer.Size = new Size(662, 520);
             _tabControlViewer.TabIndex = 1;
             // 
             // _tabPageSpatial
@@ -151,7 +151,7 @@
             _tabPageSpatial.Margin = new Padding(4, 5, 4, 5);
             _tabPageSpatial.Name = "_tabPageSpatial";
             _tabPageSpatial.Padding = new Padding(4, 5, 4, 5);
-            _tabPageSpatial.Size = new Size(654, 376);
+            _tabPageSpatial.Size = new Size(654, 487);
             _tabPageSpatial.TabIndex = 0;
             _tabPageSpatial.Text = "Spatial Viewer";
             _tabPageSpatial.UseVisualStyleBackColor = true;
@@ -163,7 +163,7 @@
             _tabPageRawData.Location = new Point(4, 29);
             _tabPageRawData.Margin = new Padding(4, 5, 4, 5);
             _tabPageRawData.Name = "_tabPageRawData";
-            _tabPageRawData.Size = new Size(654, 376);
+            _tabPageRawData.Size = new Size(654, 487);
             _tabPageRawData.TabIndex = 1;
             _tabPageRawData.Text = "Raw data Viewer";
             _tabPageRawData.UseVisualStyleBackColor = true;
@@ -181,7 +181,7 @@
             _tableLayoutPanelRawData.RowCount = 2;
             _tableLayoutPanelRawData.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             _tableLayoutPanelRawData.RowStyles.Add(new RowStyle());
-            _tableLayoutPanelRawData.Size = new Size(654, 376);
+            _tableLayoutPanelRawData.Size = new Size(654, 487);
             _tableLayoutPanelRawData.TabIndex = 2;
             // 
             // _dataGridViewRawData
@@ -192,7 +192,7 @@
             _dataGridViewRawData.Margin = new Padding(4, 5, 4, 5);
             _dataGridViewRawData.Name = "_dataGridViewRawData";
             _dataGridViewRawData.RowHeadersWidth = 62;
-            _dataGridViewRawData.Size = new Size(646, 321);
+            _dataGridViewRawData.Size = new Size(646, 432);
             _dataGridViewRawData.TabIndex = 0;
             _dataGridViewRawData.ColumnAdded += _dataGridViewRawData_ColumnAdded;
             _dataGridViewRawData.Paint += _dataGridViewRawData_Paint;
@@ -200,7 +200,7 @@
             // _buttonExportRawData
             // 
             _buttonExportRawData.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            _buttonExportRawData.Location = new Point(531, 336);
+            _buttonExportRawData.Location = new Point(531, 447);
             _buttonExportRawData.Margin = new Padding(4, 5, 4, 5);
             _buttonExportRawData.Name = "_buttonExportRawData";
             _buttonExportRawData.Size = new Size(119, 35);
@@ -311,7 +311,7 @@
             _dataGridViewTotals.Name = "_dataGridViewTotals";
             _dataGridViewTotals.RowHeadersVisible = false;
             _dataGridViewTotals.RowHeadersWidth = 62;
-            _dataGridViewTotals.Size = new Size(662, 203);
+            _dataGridViewTotals.Size = new Size(662, 92);
             _dataGridViewTotals.TabIndex = 1;
             // 
             // _dataGridColumnDescription
@@ -460,6 +460,7 @@
             // 
             // workingDataComboBox
             // 
+            workingDataComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
             workingDataComboBox.FormattingEnabled = true;
             workingDataComboBox.Location = new Point(352, 17);
             workingDataComboBox.Margin = new Padding(2);

--- a/Visualizer/UI/MainForm.Designer.cs
+++ b/Visualizer/UI/MainForm.Designer.cs
@@ -294,6 +294,7 @@
             _maxColumnsNumericUpDown.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             _maxColumnsNumericUpDown.Location = new Point(364, 8);
             _maxColumnsNumericUpDown.Margin = new Padding(3, 0, 3, 0);
+            _maxColumnsNumericUpDown.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
             _maxColumnsNumericUpDown.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
             _maxColumnsNumericUpDown.Name = "_maxColumnsNumericUpDown";
             _maxColumnsNumericUpDown.Size = new Size(57, 27);

--- a/Visualizer/UI/MainForm.Designer.cs
+++ b/Visualizer/UI/MainForm.Designer.cs
@@ -29,396 +29,526 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-            this._splitContainerViewer = new System.Windows.Forms.SplitContainer();
-            this._treeViewMetadata = new System.Windows.Forms.TreeView();
-            this._splitContainerMap = new System.Windows.Forms.SplitContainer();
-            this._tabControlViewer = new System.Windows.Forms.TabControl();
-            this._tabPageSpatial = new System.Windows.Forms.TabPage();
-            this._tabPageRawData = new System.Windows.Forms.TabPage();
-            this._buttonExportRawData = new System.Windows.Forms.Button();
-            this._dataGridViewRawData = new System.Windows.Forms.DataGridView();
-            this._dataGridViewTotals = new System.Windows.Forms.DataGridView();
-            this._dataGridColumnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this._dataGridColumnValue = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this._labelTotals = new System.Windows.Forms.Label();
-            this._toolStrip = new System.Windows.Forms.ToolStrip();
-            this._importToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this._exportToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this._findToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this._aboutToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this._menuStrip = new System.Windows.Forms.MenuStrip();
-            this._dummyMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this._importMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this._exportMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this._findMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this._findNextMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.workingDataComboBox = new System.Windows.Forms.ComboBox();
-            ((System.ComponentModel.ISupportInitialize)(this._splitContainerViewer)).BeginInit();
-            this._splitContainerViewer.Panel1.SuspendLayout();
-            this._splitContainerViewer.Panel2.SuspendLayout();
-            this._splitContainerViewer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._splitContainerMap)).BeginInit();
-            this._splitContainerMap.Panel1.SuspendLayout();
-            this._splitContainerMap.Panel2.SuspendLayout();
-            this._splitContainerMap.SuspendLayout();
-            this._tabControlViewer.SuspendLayout();
-            this._tabPageRawData.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._dataGridViewRawData)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this._dataGridViewTotals)).BeginInit();
-            this._toolStrip.SuspendLayout();
-            this._menuStrip.SuspendLayout();
-            this.SuspendLayout();
+            _splitContainerViewer = new SplitContainer();
+            _treeViewMetadata = new TreeView();
+            _splitContainerMap = new SplitContainer();
+            _tabControlViewer = new TabControl();
+            _tabPageSpatial = new TabPage();
+            _tabPageRawData = new TabPage();
+            _tableLayoutPanelRawData = new TableLayoutPanel();
+            _dataGridViewRawData = new DataGridView();
+            _buttonExportRawData = new Button();
+            _limitDataPanel = new TableLayoutPanel();
+            _limitDataCheckBox = new CheckBox();
+            _maxRowsLabel = new Label();
+            _maxColumnsLabel = new Label();
+            _maxRowsNumericUpDown = new NumericUpDown();
+            _maxColumnsNumericUpDown = new NumericUpDown();
+            _dataGridViewTotals = new DataGridView();
+            _dataGridColumnDescription = new DataGridViewTextBoxColumn();
+            _dataGridColumnValue = new DataGridViewTextBoxColumn();
+            _labelTotals = new Label();
+            _toolStrip = new ToolStrip();
+            _importToolStripButton = new ToolStripButton();
+            _exportToolStripButton = new ToolStripButton();
+            _findToolStripButton = new ToolStripButton();
+            _settingsToolStripButton = new ToolStripButton();
+            _aboutToolStripButton = new ToolStripButton();
+            _menuStrip = new MenuStrip();
+            _dummyMenuItem = new ToolStripMenuItem();
+            _importMenuItem = new ToolStripMenuItem();
+            _exportMenuItem = new ToolStripMenuItem();
+            _findMenuItem = new ToolStripMenuItem();
+            _findNextMenuItem = new ToolStripMenuItem();
+            workingDataComboBox = new ComboBox();
+            ((System.ComponentModel.ISupportInitialize)_splitContainerViewer).BeginInit();
+            _splitContainerViewer.Panel1.SuspendLayout();
+            _splitContainerViewer.Panel2.SuspendLayout();
+            _splitContainerViewer.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)_splitContainerMap).BeginInit();
+            _splitContainerMap.Panel1.SuspendLayout();
+            _splitContainerMap.Panel2.SuspendLayout();
+            _splitContainerMap.SuspendLayout();
+            _tabControlViewer.SuspendLayout();
+            _tabPageRawData.SuspendLayout();
+            _tableLayoutPanelRawData.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)_dataGridViewRawData).BeginInit();
+            _limitDataPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)_maxRowsNumericUpDown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)_maxColumnsNumericUpDown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)_dataGridViewTotals).BeginInit();
+            _toolStrip.SuspendLayout();
+            _menuStrip.SuspendLayout();
+            SuspendLayout();
             // 
             // _splitContainerViewer
             // 
-            this._splitContainerViewer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._splitContainerViewer.Location = new System.Drawing.Point(0, 194);
-            this._splitContainerViewer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._splitContainerViewer.Name = "_splitContainerViewer";
+            _splitContainerViewer.Dock = DockStyle.Fill;
+            _splitContainerViewer.Location = new Point(0, 79);
+            _splitContainerViewer.Margin = new Padding(4, 5, 4, 5);
+            _splitContainerViewer.Name = "_splitContainerViewer";
             // 
             // _splitContainerViewer.Panel1
             // 
-            this._splitContainerViewer.Panel1.Controls.Add(this._treeViewMetadata);
+            _splitContainerViewer.Panel1.Controls.Add(_treeViewMetadata);
             // 
             // _splitContainerViewer.Panel2
             // 
-            this._splitContainerViewer.Panel2.Controls.Add(this._splitContainerMap);
-            this._splitContainerViewer.Size = new System.Drawing.Size(1497, 948);
-            this._splitContainerViewer.SplitterDistance = 373;
-            this._splitContainerViewer.SplitterWidth = 6;
-            this._splitContainerViewer.TabIndex = 0;
+            _splitContainerViewer.Panel2.Controls.Add(_splitContainerMap);
+            _splitContainerViewer.Size = new Size(887, 682);
+            _splitContainerViewer.SplitterDistance = 221;
+            _splitContainerViewer.TabIndex = 1;
+            _splitContainerViewer.SplitterMoved += _splitContainerViewer_SplitterMoved;
             // 
             // _treeViewMetadata
             // 
-            this._treeViewMetadata.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._treeViewMetadata.Location = new System.Drawing.Point(0, 0);
-            this._treeViewMetadata.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._treeViewMetadata.Name = "_treeViewMetadata";
-            this._treeViewMetadata.Size = new System.Drawing.Size(373, 948);
-            this._treeViewMetadata.TabIndex = 0;
-            this._treeViewMetadata.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this._treeViewMetadata_NodeMouseClick);
+            _treeViewMetadata.Dock = DockStyle.Fill;
+            _treeViewMetadata.Location = new Point(0, 0);
+            _treeViewMetadata.Margin = new Padding(4, 5, 4, 5);
+            _treeViewMetadata.Name = "_treeViewMetadata";
+            _treeViewMetadata.Size = new Size(221, 682);
+            _treeViewMetadata.TabIndex = 0;
+            _treeViewMetadata.NodeMouseClick += _treeViewMetadata_NodeMouseClick;
             // 
             // _splitContainerMap
             // 
-            this._splitContainerMap.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._splitContainerMap.Location = new System.Drawing.Point(0, 0);
-            this._splitContainerMap.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._splitContainerMap.Name = "_splitContainerMap";
-            this._splitContainerMap.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            _splitContainerMap.Dock = DockStyle.Fill;
+            _splitContainerMap.Location = new Point(0, 0);
+            _splitContainerMap.Margin = new Padding(4, 5, 4, 5);
+            _splitContainerMap.Name = "_splitContainerMap";
+            _splitContainerMap.Orientation = Orientation.Horizontal;
             // 
             // _splitContainerMap.Panel1
             // 
-            this._splitContainerMap.Panel1.Controls.Add(this._tabControlViewer);
+            _splitContainerMap.Panel1.Controls.Add(_tabControlViewer);
+            _splitContainerMap.Panel1.Controls.Add(_limitDataPanel);
             // 
             // _splitContainerMap.Panel2
             // 
-            this._splitContainerMap.Panel2.Controls.Add(this._dataGridViewTotals);
-            this._splitContainerMap.Panel2.Controls.Add(this._labelTotals);
-            this._splitContainerMap.Size = new System.Drawing.Size(1118, 948);
-            this._splitContainerMap.SplitterDistance = 631;
-            this._splitContainerMap.SplitterWidth = 6;
-            this._splitContainerMap.TabIndex = 0;
+            _splitContainerMap.Panel2.Controls.Add(_dataGridViewTotals);
+            _splitContainerMap.Panel2.Controls.Add(_labelTotals);
+            _splitContainerMap.Size = new Size(662, 682);
+            _splitContainerMap.SplitterDistance = 453;
+            _splitContainerMap.SplitterWidth = 6;
+            _splitContainerMap.TabIndex = 0;
+            _splitContainerMap.SplitterMoved += _splitContainerMap_SplitterMoved;
             // 
             // _tabControlViewer
             // 
-            this._tabControlViewer.Controls.Add(this._tabPageSpatial);
-            this._tabControlViewer.Controls.Add(this._tabPageRawData);
-            this._tabControlViewer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._tabControlViewer.Location = new System.Drawing.Point(0, 0);
-            this._tabControlViewer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._tabControlViewer.Name = "_tabControlViewer";
-            this._tabControlViewer.SelectedIndex = 0;
-            this._tabControlViewer.Size = new System.Drawing.Size(1118, 631);
-            this._tabControlViewer.TabIndex = 0;
+            _tabControlViewer.Controls.Add(_tabPageSpatial);
+            _tabControlViewer.Controls.Add(_tabPageRawData);
+            _tabControlViewer.Dock = DockStyle.Fill;
+            _tabControlViewer.Location = new Point(0, 44);
+            _tabControlViewer.Margin = new Padding(4, 5, 4, 5);
+            _tabControlViewer.Name = "_tabControlViewer";
+            _tabControlViewer.SelectedIndex = 0;
+            _tabControlViewer.Size = new Size(662, 409);
+            _tabControlViewer.TabIndex = 1;
             // 
             // _tabPageSpatial
             // 
-            this._tabPageSpatial.Location = new System.Drawing.Point(4, 29);
-            this._tabPageSpatial.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._tabPageSpatial.Name = "_tabPageSpatial";
-            this._tabPageSpatial.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._tabPageSpatial.Size = new System.Drawing.Size(1110, 670);
-            this._tabPageSpatial.TabIndex = 0;
-            this._tabPageSpatial.Text = "Spatial Viewer";
-            this._tabPageSpatial.UseVisualStyleBackColor = true;
-            this._tabPageSpatial.Paint += new System.Windows.Forms.PaintEventHandler(this._tabPageSpatial_Paint);
+            _tabPageSpatial.Location = new Point(4, 29);
+            _tabPageSpatial.Margin = new Padding(4, 5, 4, 5);
+            _tabPageSpatial.Name = "_tabPageSpatial";
+            _tabPageSpatial.Padding = new Padding(4, 5, 4, 5);
+            _tabPageSpatial.Size = new Size(654, 376);
+            _tabPageSpatial.TabIndex = 0;
+            _tabPageSpatial.Text = "Spatial Viewer";
+            _tabPageSpatial.UseVisualStyleBackColor = true;
+            _tabPageSpatial.Paint += _tabPageSpatial_Paint;
             // 
             // _tabPageRawData
             // 
-            this._tabPageRawData.Controls.Add(this._buttonExportRawData);
-            this._tabPageRawData.Controls.Add(this._dataGridViewRawData);
-            this._tabPageRawData.Location = new System.Drawing.Point(4, 29);
-            this._tabPageRawData.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._tabPageRawData.Name = "_tabPageRawData";
-            this._tabPageRawData.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._tabPageRawData.Size = new System.Drawing.Size(1110, 598);
-            this._tabPageRawData.TabIndex = 1;
-            this._tabPageRawData.Text = "Raw data Viewer";
-            this._tabPageRawData.UseVisualStyleBackColor = true;
+            _tabPageRawData.Controls.Add(_tableLayoutPanelRawData);
+            _tabPageRawData.Location = new Point(4, 29);
+            _tabPageRawData.Margin = new Padding(4, 5, 4, 5);
+            _tabPageRawData.Name = "_tabPageRawData";
+            _tabPageRawData.Size = new Size(654, 376);
+            _tabPageRawData.TabIndex = 1;
+            _tabPageRawData.Text = "Raw data Viewer";
+            _tabPageRawData.UseVisualStyleBackColor = true;
             // 
-            // _buttonExportRawData
+            // _tableLayoutPanelRawData
             // 
-            this._buttonExportRawData.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this._buttonExportRawData.Location = new System.Drawing.Point(951, 528);
-            this._buttonExportRawData.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._buttonExportRawData.Name = "_buttonExportRawData";
-            this._buttonExportRawData.Size = new System.Drawing.Size(134, 35);
-            this._buttonExportRawData.TabIndex = 1;
-            this._buttonExportRawData.Text = "Export";
-            this._buttonExportRawData.UseVisualStyleBackColor = true;
-            this._buttonExportRawData.Click += new System.EventHandler(this._buttonExportRawData_Click);
+            _tableLayoutPanelRawData.ColumnCount = 1;
+            _tableLayoutPanelRawData.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _tableLayoutPanelRawData.Controls.Add(_dataGridViewRawData, 0, 0);
+            _tableLayoutPanelRawData.Controls.Add(_buttonExportRawData, 0, 1);
+            _tableLayoutPanelRawData.Dock = DockStyle.Fill;
+            _tableLayoutPanelRawData.Location = new Point(0, 0);
+            _tableLayoutPanelRawData.Margin = new Padding(0);
+            _tableLayoutPanelRawData.Name = "_tableLayoutPanelRawData";
+            _tableLayoutPanelRawData.RowCount = 2;
+            _tableLayoutPanelRawData.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            _tableLayoutPanelRawData.RowStyles.Add(new RowStyle());
+            _tableLayoutPanelRawData.Size = new Size(654, 376);
+            _tableLayoutPanelRawData.TabIndex = 2;
             // 
             // _dataGridViewRawData
             // 
-            this._dataGridViewRawData.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this._dataGridViewRawData.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this._dataGridViewRawData.Location = new System.Drawing.Point(4, 5);
-            this._dataGridViewRawData.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._dataGridViewRawData.Name = "_dataGridViewRawData";
-            this._dataGridViewRawData.RowHeadersWidth = 62;
-            this._dataGridViewRawData.Size = new System.Drawing.Size(1090, 517);
-            this._dataGridViewRawData.TabIndex = 0;
-            this._dataGridViewRawData.ColumnAdded += new System.Windows.Forms.DataGridViewColumnEventHandler(this._dataGridViewRawData_ColumnAdded);
-            this._dataGridViewRawData.Paint += new System.Windows.Forms.PaintEventHandler(this._dataGridViewRawData_Paint);
+            _dataGridViewRawData.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            _dataGridViewRawData.Dock = DockStyle.Fill;
+            _dataGridViewRawData.Location = new Point(0, 0);
+            _dataGridViewRawData.Margin = new Padding(0);
+            _dataGridViewRawData.Name = "_dataGridViewRawData";
+            _dataGridViewRawData.RowHeadersWidth = 62;
+            _dataGridViewRawData.Size = new Size(654, 329);
+            _dataGridViewRawData.TabIndex = 0;
+            _dataGridViewRawData.ColumnAdded += _dataGridViewRawData_ColumnAdded;
+            _dataGridViewRawData.Paint += _dataGridViewRawData_Paint;
+            // 
+            // _buttonExportRawData
+            // 
+            _buttonExportRawData.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            _buttonExportRawData.Location = new Point(529, 335);
+            _buttonExportRawData.Margin = new Padding(6);
+            _buttonExportRawData.Name = "_buttonExportRawData";
+            _buttonExportRawData.Size = new Size(119, 35);
+            _buttonExportRawData.TabIndex = 1;
+            _buttonExportRawData.Text = "Export";
+            _buttonExportRawData.UseVisualStyleBackColor = true;
+            _buttonExportRawData.Click += _buttonExportRawData_Click;
+            // 
+            // _limitDataPanel
+            // 
+            _limitDataPanel.AutoSize = true;
+            _limitDataPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _limitDataPanel.ColumnCount = 6;
+            _limitDataPanel.ColumnStyles.Add(new ColumnStyle());
+            _limitDataPanel.ColumnStyles.Add(new ColumnStyle());
+            _limitDataPanel.ColumnStyles.Add(new ColumnStyle());
+            _limitDataPanel.ColumnStyles.Add(new ColumnStyle());
+            _limitDataPanel.ColumnStyles.Add(new ColumnStyle());
+            _limitDataPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _limitDataPanel.Controls.Add(_limitDataCheckBox, 0, 0);
+            _limitDataPanel.Controls.Add(_maxRowsLabel, 1, 0);
+            _limitDataPanel.Controls.Add(_maxColumnsLabel, 3, 0);
+            _limitDataPanel.Controls.Add(_maxRowsNumericUpDown, 2, 0);
+            _limitDataPanel.Controls.Add(_maxColumnsNumericUpDown, 4, 0);
+            _limitDataPanel.Dock = DockStyle.Top;
+            _limitDataPanel.Location = new Point(0, 0);
+            _limitDataPanel.Margin = new Padding(3, 4, 3, 4);
+            _limitDataPanel.Name = "_limitDataPanel";
+            _limitDataPanel.Padding = new Padding(0, 6, 0, 6);
+            _limitDataPanel.RowCount = 1;
+            _limitDataPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            _limitDataPanel.Size = new Size(662, 44);
+            _limitDataPanel.TabIndex = 0;
+            _limitDataPanel.VisibleChanged += _limitDataPanel_VisibleChanged;
+            // 
+            // _limitDataCheckBox
+            // 
+            _limitDataCheckBox.Anchor = AnchorStyles.Left;
+            _limitDataCheckBox.AutoSize = true;
+            _limitDataCheckBox.Location = new Point(3, 10);
+            _limitDataCheckBox.Margin = new Padding(3, 4, 3, 4);
+            _limitDataCheckBox.Name = "_limitDataCheckBox";
+            _limitDataCheckBox.Size = new Size(100, 24);
+            _limitDataCheckBox.TabIndex = 0;
+            _limitDataCheckBox.Text = "Limit Data";
+            _limitDataCheckBox.UseVisualStyleBackColor = true;
+            _limitDataCheckBox.CheckedChanged += _limitDataCheckBox_CheckedChanged;
+            // 
+            // _maxRowsLabel
+            // 
+            _maxRowsLabel.Anchor = AnchorStyles.Left;
+            _maxRowsLabel.AutoSize = true;
+            _maxRowsLabel.Enabled = false;
+            _maxRowsLabel.Location = new Point(112, 12);
+            _maxRowsLabel.Margin = new Padding(6, 0, 3, 0);
+            _maxRowsLabel.Name = "_maxRowsLabel";
+            _maxRowsLabel.Size = new Size(76, 20);
+            _maxRowsLabel.TabIndex = 1;
+            _maxRowsLabel.Text = "Max Rows";
+            // 
+            // _maxColumnsLabel
+            // 
+            _maxColumnsLabel.Anchor = AnchorStyles.Left;
+            _maxColumnsLabel.AutoSize = true;
+            _maxColumnsLabel.Enabled = false;
+            _maxColumnsLabel.Location = new Point(260, 12);
+            _maxColumnsLabel.Margin = new Padding(6, 0, 3, 0);
+            _maxColumnsLabel.Name = "_maxColumnsLabel";
+            _maxColumnsLabel.Size = new Size(98, 20);
+            _maxColumnsLabel.TabIndex = 3;
+            _maxColumnsLabel.Text = "Max Columns";
+            // 
+            // _maxRowsNumericUpDown
+            // 
+            _maxRowsNumericUpDown.Anchor = AnchorStyles.Left;
+            _maxRowsNumericUpDown.Enabled = false;
+            _maxRowsNumericUpDown.Increment = new decimal(new int[] { 100, 0, 0, 0 });
+            _maxRowsNumericUpDown.Location = new Point(194, 8);
+            _maxRowsNumericUpDown.Margin = new Padding(3, 0, 3, 0);
+            _maxRowsNumericUpDown.Maximum = new decimal(new int[] { 100000, 0, 0, 0 });
+            _maxRowsNumericUpDown.Name = "_maxRowsNumericUpDown";
+            _maxRowsNumericUpDown.Size = new Size(57, 27);
+            _maxRowsNumericUpDown.TabIndex = 2;
+            _maxRowsNumericUpDown.Value = new decimal(new int[] { 100, 0, 0, 0 });
+            _maxRowsNumericUpDown.ValueChanged += _maxRowsNumericUpDown_ValueChanged;
+            // 
+            // _maxColumnsNumericUpDown
+            // 
+            _maxColumnsNumericUpDown.Anchor = AnchorStyles.Left;
+            _maxColumnsNumericUpDown.Enabled = false;
+            _maxColumnsNumericUpDown.Increment = new decimal(new int[] { 10, 0, 0, 0 });
+            _maxColumnsNumericUpDown.Location = new Point(364, 8);
+            _maxColumnsNumericUpDown.Margin = new Padding(3, 0, 3, 0);
+            _maxColumnsNumericUpDown.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
+            _maxColumnsNumericUpDown.Name = "_maxColumnsNumericUpDown";
+            _maxColumnsNumericUpDown.Size = new Size(57, 27);
+            _maxColumnsNumericUpDown.TabIndex = 4;
+            _maxColumnsNumericUpDown.Value = new decimal(new int[] { 50, 0, 0, 0 });
+            _maxColumnsNumericUpDown.ValueChanged += _maxColumnsNumericUpDown_ValueChanged;
             // 
             // _dataGridViewTotals
             // 
-            this._dataGridViewTotals.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this._dataGridViewTotals.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this._dataGridColumnDescription,
-            this._dataGridColumnValue});
-            this._dataGridViewTotals.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._dataGridViewTotals.Location = new System.Drawing.Point(0, 20);
-            this._dataGridViewTotals.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this._dataGridViewTotals.Name = "_dataGridViewTotals";
-            this._dataGridViewTotals.RowHeadersVisible = false;
-            this._dataGridViewTotals.RowHeadersWidth = 62;
-            this._dataGridViewTotals.Size = new System.Drawing.Size(1118, 291);
-            this._dataGridViewTotals.TabIndex = 1;
+            _dataGridViewTotals.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            _dataGridViewTotals.Columns.AddRange(new DataGridViewColumn[] { _dataGridColumnDescription, _dataGridColumnValue });
+            _dataGridViewTotals.Dock = DockStyle.Fill;
+            _dataGridViewTotals.Location = new Point(0, 20);
+            _dataGridViewTotals.Margin = new Padding(4, 5, 4, 5);
+            _dataGridViewTotals.Name = "_dataGridViewTotals";
+            _dataGridViewTotals.RowHeadersVisible = false;
+            _dataGridViewTotals.RowHeadersWidth = 62;
+            _dataGridViewTotals.Size = new Size(662, 203);
+            _dataGridViewTotals.TabIndex = 1;
             // 
             // _dataGridColumnDescription
             // 
-            this._dataGridColumnDescription.HeaderText = "Description";
-            this._dataGridColumnDescription.MinimumWidth = 8;
-            this._dataGridColumnDescription.Name = "_dataGridColumnDescription";
-            this._dataGridColumnDescription.Width = 250;
+            _dataGridColumnDescription.HeaderText = "Description";
+            _dataGridColumnDescription.MinimumWidth = 8;
+            _dataGridColumnDescription.Name = "_dataGridColumnDescription";
+            _dataGridColumnDescription.Width = 250;
             // 
             // _dataGridColumnValue
             // 
-            this._dataGridColumnValue.HeaderText = "Value";
-            this._dataGridColumnValue.MinimumWidth = 8;
-            this._dataGridColumnValue.Name = "_dataGridColumnValue";
-            this._dataGridColumnValue.Width = 150;
+            _dataGridColumnValue.HeaderText = "Value";
+            _dataGridColumnValue.MinimumWidth = 8;
+            _dataGridColumnValue.Name = "_dataGridColumnValue";
+            _dataGridColumnValue.Width = 150;
             // 
             // _labelTotals
             // 
-            this._labelTotals.AutoSize = true;
-            this._labelTotals.Dock = System.Windows.Forms.DockStyle.Top;
-            this._labelTotals.Location = new System.Drawing.Point(0, 0);
-            this._labelTotals.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this._labelTotals.Name = "_labelTotals";
-            this._labelTotals.Size = new System.Drawing.Size(52, 20);
-            this._labelTotals.TabIndex = 0;
-            this._labelTotals.Text = "Totals";
+            _labelTotals.AutoSize = true;
+            _labelTotals.Dock = DockStyle.Top;
+            _labelTotals.Location = new Point(0, 0);
+            _labelTotals.Name = "_labelTotals";
+            _labelTotals.Size = new Size(48, 20);
+            _labelTotals.TabIndex = 0;
+            _labelTotals.Text = "Totals";
             // 
             // _toolStrip
             // 
-            this._toolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this._toolStrip.ImageScalingSize = new System.Drawing.Size(32, 32);
-            this._toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this._importToolStripButton,
-            this._exportToolStripButton,
-            this._findToolStripButton,
-            this._aboutToolStripButton});
-            this._toolStrip.Location = new System.Drawing.Point(0, 0);
-            this._toolStrip.Name = "_toolStrip";
-            this._toolStrip.Size = new System.Drawing.Size(1497, 129);
-            this._toolStrip.TabIndex = 9;
-            this._toolStrip.Text = "toolStrip1";
+            _toolStrip.GripStyle = ToolStripGripStyle.Hidden;
+            _toolStrip.ImageScalingSize = new Size(32, 32);
+            _toolStrip.Items.AddRange(new ToolStripItem[] { _importToolStripButton, _exportToolStripButton, _findToolStripButton, _settingsToolStripButton, _aboutToolStripButton });
+            _toolStrip.Location = new Point(0, 0);
+            _toolStrip.Name = "_toolStrip";
+            _toolStrip.Size = new Size(887, 79);
+            _toolStrip.TabIndex = 2;
+            _toolStrip.Text = "toolStrip1";
             // 
             // _importToolStripButton
             // 
-            this._importToolStripButton.Image = global::AgGateway.ADAPT.Visualizer.Properties.Resources.Enter;
-            this._importToolStripButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this._importToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this._importToolStripButton.Name = "_importToolStripButton";
-            this._importToolStripButton.Size = new System.Drawing.Size(71, 124);
-            this._importToolStripButton.Text = "Import";
-            this._importToolStripButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
-            this._importToolStripButton.ToolTipText = "Import (Ctrl+I)";
-            this._importToolStripButton.Click += new System.EventHandler(this._importToolStripButton_Click);
+            _importToolStripButton.Image = Properties.Resources.Enter;
+            _importToolStripButton.ImageScaling = ToolStripItemImageScaling.None;
+            _importToolStripButton.ImageTransparentColor = Color.Magenta;
+            _importToolStripButton.Name = "_importToolStripButton";
+            _importToolStripButton.Size = new Size(58, 76);
+            _importToolStripButton.Text = "Import";
+            _importToolStripButton.TextImageRelation = TextImageRelation.ImageAboveText;
+            _importToolStripButton.ToolTipText = "Import (Ctrl+I)";
+            _importToolStripButton.Click += _importToolStripButton_Click;
             // 
             // _exportToolStripButton
             // 
-            this._exportToolStripButton.Image = global::AgGateway.ADAPT.Visualizer.Properties.Resources.Exit;
-            this._exportToolStripButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this._exportToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this._exportToolStripButton.Name = "_exportToolStripButton";
-            this._exportToolStripButton.Size = new System.Drawing.Size(67, 124);
-            this._exportToolStripButton.Text = "Export";
-            this._exportToolStripButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
-            this._exportToolStripButton.ToolTipText = "Export (Ctrl+E)";
-            this._exportToolStripButton.Click += new System.EventHandler(this._exportToolStripButton_Click);
+            _exportToolStripButton.Image = Properties.Resources.Exit;
+            _exportToolStripButton.ImageScaling = ToolStripItemImageScaling.None;
+            _exportToolStripButton.ImageTransparentColor = Color.Magenta;
+            _exportToolStripButton.Name = "_exportToolStripButton";
+            _exportToolStripButton.Size = new Size(56, 76);
+            _exportToolStripButton.Text = "Export";
+            _exportToolStripButton.TextImageRelation = TextImageRelation.ImageAboveText;
+            _exportToolStripButton.ToolTipText = "Export (Ctrl+E)";
+            _exportToolStripButton.Click += _exportToolStripButton_Click;
             // 
             // _findToolStripButton
             // 
-            this._findToolStripButton.Image = global::AgGateway.ADAPT.Visualizer.Properties.Resources.Search;
-            this._findToolStripButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this._findToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this._findToolStripButton.Name = "_findToolStripButton";
-            this._findToolStripButton.Size = new System.Drawing.Size(56, 124);
-            this._findToolStripButton.Text = "Find";
-            this._findToolStripButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
-            this._findToolStripButton.ToolTipText = "Find (Ctrl+F)";
-            this._findToolStripButton.Click += new System.EventHandler(this._findMenuItem_Click);
+            _findToolStripButton.Image = Properties.Resources.Search;
+            _findToolStripButton.ImageScaling = ToolStripItemImageScaling.None;
+            _findToolStripButton.ImageTransparentColor = Color.Magenta;
+            _findToolStripButton.Name = "_findToolStripButton";
+            _findToolStripButton.Size = new Size(56, 76);
+            _findToolStripButton.Text = "Find";
+            _findToolStripButton.TextImageRelation = TextImageRelation.ImageAboveText;
+            _findToolStripButton.ToolTipText = "Find (Ctrl+F)";
+            _findToolStripButton.Click += _findMenuItem_Click;
+            // 
+            // _settingsToolStripButton
+            // 
+            _settingsToolStripButton.Image = Properties.Resources.Settings_3;
+            _settingsToolStripButton.ImageScaling = ToolStripItemImageScaling.None;
+            _settingsToolStripButton.ImageTransparentColor = Color.Magenta;
+            _settingsToolStripButton.Name = "_settingsToolStripButton";
+            _settingsToolStripButton.Size = new Size(66, 76);
+            _settingsToolStripButton.Text = "Settings";
+            _settingsToolStripButton.TextImageRelation = TextImageRelation.ImageAboveText;
+            _settingsToolStripButton.Click += _settingsToolStripButton_Click;
             // 
             // _aboutToolStripButton
             // 
-            this._aboutToolStripButton.Image = global::AgGateway.ADAPT.Visualizer.Properties.Resources.About_52;
-            this._aboutToolStripButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this._aboutToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this._aboutToolStripButton.Name = "_aboutToolStripButton";
-            this._aboutToolStripButton.Size = new System.Drawing.Size(66, 124);
-            this._aboutToolStripButton.Text = "About";
-            this._aboutToolStripButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
-            this._aboutToolStripButton.Click += new System.EventHandler(this._aboutToolStripButton_Click);
+            _aboutToolStripButton.Image = Properties.Resources.About_52;
+            _aboutToolStripButton.ImageScaling = ToolStripItemImageScaling.None;
+            _aboutToolStripButton.ImageTransparentColor = Color.Magenta;
+            _aboutToolStripButton.Name = "_aboutToolStripButton";
+            _aboutToolStripButton.Size = new Size(56, 76);
+            _aboutToolStripButton.Text = "About";
+            _aboutToolStripButton.TextImageRelation = TextImageRelation.ImageAboveText;
+            _aboutToolStripButton.Click += _aboutToolStripButton_Click;
             // 
             // _menuStrip
             // 
-            this._menuStrip.GripMargin = new System.Windows.Forms.Padding(2, 2, 0, 2);
-            this._menuStrip.ImageScalingSize = new System.Drawing.Size(32, 32);
-            this._menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this._dummyMenuItem});
-            this._menuStrip.Location = new System.Drawing.Point(0, 0);
-            this._menuStrip.Name = "_menuStrip";
-            this._menuStrip.Size = new System.Drawing.Size(1498, 37);
-            this._menuStrip.TabIndex = 10;
-            this._menuStrip.Text = "menuStrip1";
-            this._menuStrip.Visible = false;
+            _menuStrip.ImageScalingSize = new Size(32, 32);
+            _menuStrip.Items.AddRange(new ToolStripItem[] { _dummyMenuItem });
+            _menuStrip.Location = new Point(0, 0);
+            _menuStrip.Name = "_menuStrip";
+            _menuStrip.Padding = new Padding(4, 2, 0, 2);
+            _menuStrip.Size = new Size(831, 37);
+            _menuStrip.TabIndex = 10;
+            _menuStrip.Text = "menuStrip1";
+            _menuStrip.Visible = false;
             // 
             // _dummyMenuItem
             // 
-            this._dummyMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this._importMenuItem,
-            this._exportMenuItem,
-            this._findMenuItem,
-            this._findNextMenuItem});
-            this._dummyMenuItem.Name = "_dummyMenuItem";
-            this._dummyMenuItem.Size = new System.Drawing.Size(238, 33);
-            this._dummyMenuItem.Text = "{dummy_for_shorcut_keys}";
+            _dummyMenuItem.DropDownItems.AddRange(new ToolStripItem[] { _importMenuItem, _exportMenuItem, _findMenuItem, _findNextMenuItem });
+            _dummyMenuItem.Name = "_dummyMenuItem";
+            _dummyMenuItem.Size = new Size(196, 33);
+            _dummyMenuItem.Text = "{dummy_for_shorcut_keys}";
             // 
             // _importMenuItem
             // 
-            this._importMenuItem.Name = "_importMenuItem";
-            this._importMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
-            this._importMenuItem.Size = new System.Drawing.Size(225, 34);
-            this._importMenuItem.Text = "import";
-            this._importMenuItem.Click += new System.EventHandler(this._importMenuItem_Click);
+            _importMenuItem.Name = "_importMenuItem";
+            _importMenuItem.ShortcutKeys = Keys.Control | Keys.I;
+            _importMenuItem.Size = new Size(185, 26);
+            _importMenuItem.Text = "import";
+            _importMenuItem.Click += _importMenuItem_Click;
             // 
             // _exportMenuItem
             // 
-            this._exportMenuItem.Name = "_exportMenuItem";
-            this._exportMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
-            this._exportMenuItem.Size = new System.Drawing.Size(225, 34);
-            this._exportMenuItem.Text = "export";
-            this._exportMenuItem.Click += new System.EventHandler(this._exportMenuItem_Click);
+            _exportMenuItem.Name = "_exportMenuItem";
+            _exportMenuItem.ShortcutKeys = Keys.Control | Keys.E;
+            _exportMenuItem.Size = new Size(185, 26);
+            _exportMenuItem.Text = "export";
+            _exportMenuItem.Click += _exportMenuItem_Click;
             // 
             // _findMenuItem
             // 
-            this._findMenuItem.Name = "_findMenuItem";
-            this._findMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this._findMenuItem.Size = new System.Drawing.Size(225, 34);
-            this._findMenuItem.Text = "find";
-            this._findMenuItem.Click += new System.EventHandler(this._findMenuItem_Click);
+            _findMenuItem.Name = "_findMenuItem";
+            _findMenuItem.ShortcutKeys = Keys.Control | Keys.F;
+            _findMenuItem.Size = new Size(185, 26);
+            _findMenuItem.Text = "find";
+            _findMenuItem.Click += _findMenuItem_Click;
             // 
             // _findNextMenuItem
             // 
-            this._findNextMenuItem.Name = "_findNextMenuItem";
-            this._findNextMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this._findNextMenuItem.Size = new System.Drawing.Size(225, 34);
-            this._findNextMenuItem.Text = "find_next";
-            this._findNextMenuItem.Click += new System.EventHandler(this._findNextMenuItem_Click);
+            _findNextMenuItem.Name = "_findNextMenuItem";
+            _findNextMenuItem.ShortcutKeys = Keys.F3;
+            _findNextMenuItem.Size = new Size(185, 26);
+            _findNextMenuItem.Text = "find_next";
+            _findNextMenuItem.Click += _findNextMenuItem_Click;
             // 
             // workingDataComboBox
             // 
-            this.workingDataComboBox.FormattingEnabled = true;
-            this.workingDataComboBox.Location = new System.Drawing.Point(557, 17);
-            this.workingDataComboBox.Margin = new System.Windows.Forms.Padding(2);
-            this.workingDataComboBox.Name = "workingDataComboBox";
-            this.workingDataComboBox.Size = new System.Drawing.Size(533, 28);
-            this.workingDataComboBox.TabIndex = 0;
-            this.workingDataComboBox.Visible = false;
-            this.workingDataComboBox.SelectedIndexChanged += new System.EventHandler(this.workingDataComboBox_SelectedIndexChanged);
+            workingDataComboBox.FormattingEnabled = true;
+            workingDataComboBox.Location = new Point(352, 17);
+            workingDataComboBox.Margin = new Padding(2);
+            workingDataComboBox.Name = "workingDataComboBox";
+            workingDataComboBox.Size = new Size(474, 28);
+            workingDataComboBox.TabIndex = 0;
+            workingDataComboBox.Visible = false;
+            workingDataComboBox.SelectedIndexChanged += workingDataComboBox_SelectedIndexChanged;
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(998, 761);
-            this.Controls.Add(this.workingDataComboBox);
-            this.Controls.Add(this._splitContainerViewer);
-            this.Controls.Add(this._toolStrip);
-            this.Controls.Add(this._menuStrip);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this._menuStrip;
-            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.Name = "MainForm";
-            this.Text = "ADAPT - Visualizer";
-            this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MainForm_FormClosed);
-            this.Load += new System.EventHandler(this.MainForm_Load);
-            this.LocationChanged += new System.EventHandler(this.MainForm_LocationChanged);
-            this.SizeChanged += new System.EventHandler(this.MainForm_SizeChanged);
-            this._splitContainerViewer.Panel1.ResumeLayout(false);
-            this._splitContainerViewer.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this._splitContainerViewer)).EndInit();
-            this._splitContainerViewer.ResumeLayout(false);
-            this._splitContainerMap.Panel1.ResumeLayout(false);
-            this._splitContainerMap.Panel2.ResumeLayout(false);
-            this._splitContainerMap.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this._splitContainerMap)).EndInit();
-            this._splitContainerMap.ResumeLayout(false);
-            this._tabControlViewer.ResumeLayout(false);
-            this._tabPageRawData.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this._dataGridViewRawData)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this._dataGridViewTotals)).EndInit();
-            this._toolStrip.ResumeLayout(false);
-            this._toolStrip.PerformLayout();
-            this._menuStrip.ResumeLayout(false);
-            this._menuStrip.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new SizeF(8F, 20F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(887, 761);
+            Controls.Add(workingDataComboBox);
+            Controls.Add(_splitContainerViewer);
+            Controls.Add(_toolStrip);
+            Controls.Add(_menuStrip);
+            Icon = (Icon)resources.GetObject("$this.Icon");
+            MainMenuStrip = _menuStrip;
+            Margin = new Padding(4, 5, 4, 5);
+            Name = "MainForm";
+            Text = "ADAPT - Visualizer";
+            WindowState = FormWindowState.Maximized;
+            FormClosed += MainForm_FormClosed;
+            Load += MainForm_Load;
+            LocationChanged += MainForm_LocationChanged;
+            SizeChanged += MainForm_SizeChanged;
+            _splitContainerViewer.Panel1.ResumeLayout(false);
+            _splitContainerViewer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)_splitContainerViewer).EndInit();
+            _splitContainerViewer.ResumeLayout(false);
+            _splitContainerMap.Panel1.ResumeLayout(false);
+            _splitContainerMap.Panel1.PerformLayout();
+            _splitContainerMap.Panel2.ResumeLayout(false);
+            _splitContainerMap.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)_splitContainerMap).EndInit();
+            _splitContainerMap.ResumeLayout(false);
+            _tabControlViewer.ResumeLayout(false);
+            _tabPageRawData.ResumeLayout(false);
+            _tableLayoutPanelRawData.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)_dataGridViewRawData).EndInit();
+            _limitDataPanel.ResumeLayout(false);
+            _limitDataPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)_maxRowsNumericUpDown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)_maxColumnsNumericUpDown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)_dataGridViewTotals).EndInit();
+            _toolStrip.ResumeLayout(false);
+            _toolStrip.PerformLayout();
+            _menuStrip.ResumeLayout(false);
+            _menuStrip.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
 
-        private System.Windows.Forms.SplitContainer _splitContainerViewer;
-        private System.Windows.Forms.TreeView _treeViewMetadata;
-        private System.Windows.Forms.SplitContainer _splitContainerMap;
-        private System.Windows.Forms.TabControl _tabControlViewer;
-        private System.Windows.Forms.TabPage _tabPageSpatial;
-        private System.Windows.Forms.TabPage _tabPageRawData;
-        private System.Windows.Forms.Button _buttonExportRawData;
-        private System.Windows.Forms.DataGridView _dataGridViewRawData;
-        private System.Windows.Forms.DataGridView _dataGridViewTotals;
-        private System.Windows.Forms.DataGridViewTextBoxColumn _dataGridColumnDescription;
-        private System.Windows.Forms.DataGridViewTextBoxColumn _dataGridColumnValue;
-        private System.Windows.Forms.Label _labelTotals;
-        private System.Windows.Forms.ToolStripButton _importToolStripButton;
-        private System.Windows.Forms.ToolStrip _toolStrip;
-        private System.Windows.Forms.ToolStripButton _findToolStripButton;
-        private System.Windows.Forms.ToolStripButton _aboutToolStripButton;
-        private System.Windows.Forms.MenuStrip _menuStrip;
-        private System.Windows.Forms.ToolStripMenuItem _dummyMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem _importMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem _exportMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem _findMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem _findNextMenuItem;
-        private System.Windows.Forms.ToolStripButton _exportToolStripButton;
-        private System.Windows.Forms.ComboBox workingDataComboBox;
+        private SplitContainer _splitContainerViewer;
+        private TreeView _treeViewMetadata;
+        private SplitContainer _splitContainerMap;
+        private TabControl _tabControlViewer;
+        private TabPage _tabPageSpatial;
+        private TabPage _tabPageRawData;
+        private Button _buttonExportRawData;
+        private DataGridView _dataGridViewRawData;
+        private DataGridView _dataGridViewTotals;
+        private DataGridViewTextBoxColumn _dataGridColumnDescription;
+        private DataGridViewTextBoxColumn _dataGridColumnValue;
+        private Label _labelTotals;
+        private ToolStripButton _importToolStripButton;
+        private ToolStrip _toolStrip;
+        private ToolStripButton _findToolStripButton;
+        private ToolStripButton _aboutToolStripButton;
+        private MenuStrip _menuStrip;
+        private ToolStripMenuItem _dummyMenuItem;
+        private ToolStripMenuItem _importMenuItem;
+        private ToolStripMenuItem _exportMenuItem;
+        private ToolStripMenuItem _findMenuItem;
+        private ToolStripMenuItem _findNextMenuItem;
+        private ToolStripButton _exportToolStripButton;
+        private ComboBox workingDataComboBox;
+        private CheckBox _limitDataCheckBox;
+        private TableLayoutPanel _limitDataPanel;
+        private Label _maxRowsLabel;
+        private Label _maxColumnsLabel;
+        private NumericUpDown _maxRowsNumericUpDown;
+        private NumericUpDown _maxColumnsNumericUpDown;
+        private ToolStripButton _settingsToolStripButton;
+        private TableLayoutPanel _tableLayoutPanelRawData;
     }
 }
 

--- a/Visualizer/UI/MainForm.cs
+++ b/Visualizer/UI/MainForm.cs
@@ -20,6 +20,7 @@ using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.Visualizer.Properties;
 using AgGateway.ADAPT.ApplicationDataModel.Prescriptions;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 
 namespace AgGateway.ADAPT.Visualizer.UI
@@ -196,7 +197,7 @@ namespace AgGateway.ADAPT.Visualizer.UI
 
         private void _buttonExportRawData_Click(object sender, EventArgs e)
         {
-            if (ProcessedNode == null)
+            if (_dataGridViewRawData.DataSource is not DataTable dataTable)
             {
                 return;
             }
@@ -211,7 +212,7 @@ namespace AgGateway.ADAPT.Visualizer.UI
             {
                 Cursor.Current = Cursors.WaitCursor;
                 ProcessData(GetProcessDataRequest(ProcessedNode, true));
-                _model.WriteCsvFile(saveFileDialog.FileName, _dataGridViewRawData);
+                _model.WriteCsvFile(saveFileDialog.FileName, dataTable);
                 Cursor.Current = Cursors.Default;
             }
         }

--- a/Visualizer/UI/MainForm.cs
+++ b/Visualizer/UI/MainForm.cs
@@ -209,8 +209,10 @@ namespace AgGateway.ADAPT.Visualizer.UI
 
             if (saveFileDialog.ShowDialog() == DialogResult.OK)
             {
+                Cursor.Current = Cursors.WaitCursor;
                 ProcessData(GetProcessDataRequest(ProcessedNode, true));
                 _model.WriteCsvFile(saveFileDialog.FileName, _dataGridViewRawData);
+                Cursor.Current = Cursors.Default;
             }
         }
 
@@ -545,7 +547,9 @@ namespace AgGateway.ADAPT.Visualizer.UI
             _maxColumnsLabel.Enabled = limit;
             if (ProcessedNode != null)
             {
+                Cursor.Current = Cursors.WaitCursor;
                 ProcessData(GetProcessDataRequest(ProcessedNode));
+                Cursor.Current = Cursors.Default;
             }
         }
 

--- a/Visualizer/UI/MainForm.resx
+++ b/Visualizer/UI/MainForm.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="_buttonExportRawData.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="_dataGridColumnDescription.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/Visualizer/UI/ProcessDataRequest.cs
+++ b/Visualizer/UI/ProcessDataRequest.cs
@@ -1,0 +1,52 @@
+﻿/* Copyright (C) 2015-16 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015-16 Deere and Company
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    Andrew Vardeman - initial implementation
+  *******************************************************************************/
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+
+namespace AgGateway.ADAPT.Visualizer.UI
+{
+    public class ProcessDataRequest
+    {
+        public ProcessDataRequest(TreeNode node, bool limitData, int maxRows, int maxColumns)
+        {
+            Node = node;
+            LimitData = limitData;
+            MaxRows = maxRows;
+            MaxColumns = maxColumns;
+        }
+
+        public TreeNode Node { get; }
+
+        public bool LimitData { get; }
+
+        public int MaxRows { get; }
+
+        public int MaxColumns { get; }
+
+        public List<SpatialRecord>? SpatialRecords { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var that = (ProcessDataRequest)obj;
+            return Node == that.Node && LimitData == that.LimitData &&
+                   MaxRows == that.MaxRows && MaxColumns == that.MaxColumns;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Node, LimitData, MaxRows, MaxColumns);
+        }
+    }
+}

--- a/Visualizer/UI/SettingsForm.Designer.cs
+++ b/Visualizer/UI/SettingsForm.Designer.cs
@@ -1,0 +1,139 @@
+﻿namespace AgGateway.ADAPT.Visualizer.UI
+{
+    partial class SettingsForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            showLimitDataUICheckBox = new CheckBox();
+            tableLayoutPanel1 = new TableLayoutPanel();
+            okButton = new Button();
+            cancelButton = new Button();
+            rememberWindowSettingsCheckBox = new CheckBox();
+            tableLayoutPanel1.SuspendLayout();
+            SuspendLayout();
+            // 
+            // showLimitDataUICheckBox
+            // 
+            showLimitDataUICheckBox.AutoSize = true;
+            tableLayoutPanel1.SetColumnSpan(showLimitDataUICheckBox, 2);
+            showLimitDataUICheckBox.Location = new Point(6, 6);
+            showLimitDataUICheckBox.Margin = new Padding(6);
+            showLimitDataUICheckBox.Name = "showLimitDataUICheckBox";
+            showLimitDataUICheckBox.Size = new Size(158, 24);
+            showLimitDataUICheckBox.TabIndex = 0;
+            showLimitDataUICheckBox.Text = "Show Limit Data UI";
+            showLimitDataUICheckBox.UseVisualStyleBackColor = true;
+            // 
+            // tableLayoutPanel1
+            // 
+            tableLayoutPanel1.AutoSize = true;
+            tableLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel1.ColumnCount = 2;
+            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            tableLayoutPanel1.Controls.Add(showLimitDataUICheckBox, 0, 0);
+            tableLayoutPanel1.Controls.Add(okButton, 0, 2);
+            tableLayoutPanel1.Controls.Add(cancelButton, 1, 2);
+            tableLayoutPanel1.Controls.Add(rememberWindowSettingsCheckBox, 0, 1);
+            tableLayoutPanel1.Location = new Point(12, 12);
+            tableLayoutPanel1.Margin = new Padding(12);
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 3;
+            tableLayoutPanel1.RowStyles.Add(new RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new RowStyle());
+            tableLayoutPanel1.RowStyles.Add(new RowStyle());
+            tableLayoutPanel1.Size = new Size(252, 127);
+            tableLayoutPanel1.TabIndex = 1;
+            // 
+            // okButton
+            // 
+            okButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            okButton.Location = new Point(26, 92);
+            okButton.Margin = new Padding(6, 20, 6, 6);
+            okButton.Name = "okButton";
+            okButton.Size = new Size(94, 29);
+            okButton.TabIndex = 1;
+            okButton.Text = "OK";
+            okButton.UseVisualStyleBackColor = true;
+            okButton.Click += okButton_Click;
+            // 
+            // cancelButton
+            // 
+            cancelButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            cancelButton.Location = new Point(132, 92);
+            cancelButton.Margin = new Padding(6, 20, 6, 6);
+            cancelButton.Name = "cancelButton";
+            cancelButton.Size = new Size(94, 29);
+            cancelButton.TabIndex = 2;
+            cancelButton.Text = "Cancel";
+            cancelButton.UseVisualStyleBackColor = true;
+            // 
+            // rememberWindowSettingsCheckBox
+            // 
+            rememberWindowSettingsCheckBox.AutoSize = true;
+            tableLayoutPanel1.SetColumnSpan(rememberWindowSettingsCheckBox, 2);
+            rememberWindowSettingsCheckBox.Location = new Point(6, 42);
+            rememberWindowSettingsCheckBox.Margin = new Padding(6);
+            rememberWindowSettingsCheckBox.Name = "rememberWindowSettingsCheckBox";
+            rememberWindowSettingsCheckBox.Size = new Size(220, 24);
+            rememberWindowSettingsCheckBox.TabIndex = 3;
+            rememberWindowSettingsCheckBox.Text = "Remember Window Settings";
+            rememberWindowSettingsCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // SettingsForm
+            // 
+            AcceptButton = okButton;
+            AutoScaleDimensions = new SizeF(8F, 20F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            CancelButton = cancelButton;
+            ClientSize = new Size(572, 278);
+            ControlBox = false;
+            Controls.Add(tableLayoutPanel1);
+            FormBorderStyle = FormBorderStyle.Fixed3D;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "SettingsForm";
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Settings";
+            FormClosed += SettingsForm_FormClosed;
+            tableLayoutPanel1.ResumeLayout(false);
+            tableLayoutPanel1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private CheckBox showLimitDataUICheckBox;
+        private TableLayoutPanel tableLayoutPanel1;
+        private Button okButton;
+        private Button cancelButton;
+        private CheckBox rememberWindowSettingsCheckBox;
+    }
+}

--- a/Visualizer/UI/SettingsForm.cs
+++ b/Visualizer/UI/SettingsForm.cs
@@ -1,0 +1,37 @@
+﻿using System.Windows.Forms.VisualStyles;
+using AgGateway.ADAPT.Visualizer.Properties;
+
+namespace AgGateway.ADAPT.Visualizer.UI
+{
+    public partial class SettingsForm : Form
+    {
+        public SettingsForm()
+        {
+            InitializeComponent();
+            showLimitDataUICheckBox.Checked = Settings.Default.ShowLimitDataUI;
+            rememberWindowSettingsCheckBox.Checked = Settings.Default.RememberWindowSettings;
+        }
+
+        private void SettingsForm_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            if (DialogResult == DialogResult.OK)
+            {
+                bool showLimitData = showLimitDataUICheckBox.Checked;
+
+                Settings.Default.ShowLimitDataUI = showLimitData;
+                if (!showLimitData)
+                {
+                    Settings.Default.LimitData = false;
+                }
+                
+                Settings.Default.RememberWindowSettings = rememberWindowSettingsCheckBox.Checked;
+            }
+        }
+
+        private void okButton_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK; 
+            Close();
+        }
+    }
+}

--- a/Visualizer/UI/SettingsForm.cs
+++ b/Visualizer/UI/SettingsForm.cs
@@ -1,4 +1,14 @@
-﻿using System.Windows.Forms.VisualStyles;
+﻿/*******************************************************************************
+ * Copyright (c) 2015 AgGateway and ADAPT Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Andrew Vardeman - Settings for added UI features
+ *******************************************************************************/
+using System.Windows.Forms.VisualStyles;
 using AgGateway.ADAPT.Visualizer.Properties;
 
 namespace AgGateway.ADAPT.Visualizer.UI

--- a/Visualizer/UI/SettingsForm.resx
+++ b/Visualizer/UI/SettingsForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Visualizer/Visualizer.csproj
+++ b/Visualizer/Visualizer.csproj
@@ -40,6 +40,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>
@@ -47,6 +52,13 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Visualizer/Visualizer.csproj
+++ b/Visualizer/Visualizer.csproj
@@ -7,6 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>AgGateway.ADAPT.Visualizer</RootNamespace>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The main thrust of this PR is to add a bit of UI to MainForm that allows the user to specify a max number of rows and columns to load when processing an OptionsData object.

The UI is sort of ugly and probably sort of special case, so I hid it behind a user setting.

I added a Settings dialog to provide access to the setting.

Then there was only one setting in the Settings dialog, so I added an option to save and restore window state.

In the end, most of the changes are the additions to the Settings file and the inevitable rewriting of MainForm.Designer.cs by Visual Studio.  It looks like a lot got touched, but the net effect is very small.