### PR TITLE
Don't crash on Trimble data, don't crash when plugin initialization fails

### DIFF
--- a/Visualizer/DataProvider.cs
+++ b/Visualizer/DataProvider.cs
@@ -11,6 +11,7 @@
  *******************************************************************************/
 
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using AgGateway.ADAPT.ApplicationDataModel.ADM;
 using AgGateway.ADAPT.PluginManager;
 
@@ -63,9 +64,10 @@ namespace AgGateway.ADAPT.Visualizer
                         list.AddRange(plugin.Import(datacardPath, properties));
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-
+                    // Likely due to an initialize string that is valid for one plugin but not another
+                    Debug.WriteLine(ex.ToString());
                 }
             }
 			if (list.Any())
@@ -104,11 +106,20 @@ namespace AgGateway.ADAPT.Visualizer
             foreach (var availablePlugin in AvailablePlugins)
             {
                 var plugin = GetPlugin(availablePlugin.Key);
-                InitializePlugin(plugin, initializeString);
 
-                if (plugin.IsDataCardSupported(datacardPath))
+                try
                 {
-                    return plugin.ValidateDataOnCard(datacardPath);
+                    InitializePlugin(plugin, initializeString);
+
+                    if (plugin.IsDataCardSupported(datacardPath))
+                    {
+                        return plugin.ValidateDataOnCard(datacardPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Likely due to an initialize string that is valid for one plugin but not another
+                    Debug.WriteLine(ex.ToString());
                 }
             }
 

--- a/Visualizer/DataProvider.cs
+++ b/Visualizer/DataProvider.cs
@@ -7,11 +7,10 @@
  *
  * Contributors:
  *    Tarak Reddy - initial implementation
+ *    Andrew Vardeman - don't crash when initialization fails
  *******************************************************************************/
 
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using AgGateway.ADAPT.ApplicationDataModel.ADM;
 using AgGateway.ADAPT.PluginManager;
 
@@ -55,13 +54,20 @@ namespace AgGateway.ADAPT.Visualizer
 			foreach (var availablePlugin in AvailablePlugins)
             {
                 var plugin = GetPlugin(availablePlugin.Key);
-                InitializePlugin(plugin, initializeString);
-
-                if (plugin.IsDataCardSupported(datacardPath))
+                try
                 {
-	                list.AddRange(plugin.Import(datacardPath, properties));
-				}
-			}
+                    InitializePlugin(plugin, initializeString);
+
+                    if (plugin.IsDataCardSupported(datacardPath))
+                    {
+                        list.AddRange(plugin.Import(datacardPath, properties));
+                    }
+                }
+                catch (Exception)
+                {
+
+                }
+            }
 			if (list.Any())
 			{
 				return list;

--- a/Visualizer/Model.cs
+++ b/Visualizer/Model.cs
@@ -100,7 +100,7 @@ namespace AgGateway.ADAPT.Visualizer
         {
             if (_dataProvider.PluginFactory == null)
             {
-                MessageBox.Show(@"Select a valid plugin path and load them before importing a datacard.");
+                MessageBox.Show(_treeView.FindForm(),@"Select a valid plugin path and load them before importing a datacard.");
                 pluginPathTextBox.Focus();
                 return false;
             }
@@ -116,7 +116,7 @@ namespace AgGateway.ADAPT.Visualizer
 
                 if (ApplicationDataModels == null || ApplicationDataModels.Count == 0 || plugin == null)
                 {
-                    MessageBox.Show(@"Could not export, either not a comptable plugin or no data model to export");
+                    MessageBox.Show(_treeView.FindForm(), @"Could not export, either not a comptable plugin or no data model to export");
                     return;
                 }
 
@@ -129,11 +129,18 @@ namespace AgGateway.ADAPT.Visualizer
                     var selectApplicationDataModel =
                         ApplicationDataModels.First(
                             x => x.Catalog.Description.ToLower().Equals(cardProfileSelectedText.ToLower()));
-                    DataProvider.Export(plugin, 
-                                        selectApplicationDataModel, 
-                                        initializeString,
-                                        GetExportDirectory(exportPath), 
-                                        properties);
+                    try
+                    {
+                        DataProvider.Export(plugin,
+                            selectApplicationDataModel,
+                            initializeString,
+                            GetExportDirectory(exportPath),
+                            properties);
+                    }
+                    catch (Exception ex)
+                    {
+                        _treeView.Invoke(() => MessageBox.Show(_treeView.FindForm(), ex.Message));
+                    }
 
                     CurrentState = State.StateIdle;
                     _updateStatusAction(CurrentState, "Done");
@@ -141,7 +148,7 @@ namespace AgGateway.ADAPT.Visualizer
             }
             catch (Exception exception)
             {
-                MessageBox.Show(exception.Message);
+                MessageBox.Show(_treeView.FindForm(), exception.Message);
             }
         }
 
@@ -265,7 +272,7 @@ namespace AgGateway.ADAPT.Visualizer
                 ApplicationDataModels = _dataProvider.Import(datacardPath, initializeString, properties);
                 if (ApplicationDataModels == null || ApplicationDataModels.Count == 0)
                 {
-                    MessageBox.Show(@"Not supported data format.");
+                    MessageBox.Show(_treeView.FindForm(), @"Not supported data format.");
                     CurrentState = State.StateIdle;
                     _updateStatusAction(CurrentState, "Done");
                     return;
@@ -507,7 +514,7 @@ namespace AgGateway.ADAPT.Visualizer
         {
             if (textBox.Text == null || !Directory.Exists(textBox.Text))
             {
-                MessageBox.Show(String.Format(@"Select a valid {0} path.", text));
+                MessageBox.Show(_treeView.FindForm(),String.Format(@"Select a valid {0} path.", text));
                 textBox.Focus();
                 return false;
             }

--- a/Visualizer/Model.cs
+++ b/Visualizer/Model.cs
@@ -60,6 +60,8 @@ namespace AgGateway.ADAPT.Visualizer
             }
         }
 
+        private Form? TreeViewForm => _treeView?.FindForm();
+
         public Model(Action<State, string> updateStatusAction)
         {
             _updateStatusAction = updateStatusAction;
@@ -100,7 +102,7 @@ namespace AgGateway.ADAPT.Visualizer
         {
             if (_dataProvider.PluginFactory == null)
             {
-                MessageBox.Show(_treeView.FindForm(),@"Select a valid plugin path and load them before importing a datacard.");
+                MessageBox.Show(TreeViewForm,@"Select a valid plugin path and load them before importing a datacard.");
                 pluginPathTextBox.Focus();
                 return false;
             }
@@ -116,7 +118,7 @@ namespace AgGateway.ADAPT.Visualizer
 
                 if (ApplicationDataModels == null || ApplicationDataModels.Count == 0 || plugin == null)
                 {
-                    MessageBox.Show(_treeView.FindForm(), @"Could not export, either not a comptable plugin or no data model to export");
+                    MessageBox.Show(TreeViewForm, @"Could not export, either not a comptable plugin or no data model to export");
                     return;
                 }
 
@@ -139,7 +141,7 @@ namespace AgGateway.ADAPT.Visualizer
                     }
                     catch (Exception ex)
                     {
-                        _treeView.Invoke(() => MessageBox.Show(_treeView.FindForm(), ex.Message));
+                        _treeView.Invoke(() => MessageBox.Show(TreeViewForm, ex.Message));
                     }
 
                     CurrentState = State.StateIdle;
@@ -148,7 +150,7 @@ namespace AgGateway.ADAPT.Visualizer
             }
             catch (Exception exception)
             {
-                MessageBox.Show(_treeView.FindForm(), exception.Message);
+                MessageBox.Show(TreeViewForm, exception.Message);
             }
         }
 
@@ -272,7 +274,7 @@ namespace AgGateway.ADAPT.Visualizer
                 ApplicationDataModels = _dataProvider.Import(datacardPath, initializeString, properties);
                 if (ApplicationDataModels == null || ApplicationDataModels.Count == 0)
                 {
-                    MessageBox.Show(_treeView.FindForm(), @"Not supported data format.");
+                    MessageBox.Show(TreeViewForm, @"Not supported data format.");
                     CurrentState = State.StateIdle;
                     _updateStatusAction(CurrentState, "Done");
                     return;
@@ -514,7 +516,7 @@ namespace AgGateway.ADAPT.Visualizer
         {
             if (textBox.Text == null || !Directory.Exists(textBox.Text))
             {
-                MessageBox.Show(_treeView.FindForm(),String.Format(@"Select a valid {0} path.", text));
+                MessageBox.Show(TreeViewForm,String.Format(@"Select a valid {0} path.", text));
                 textBox.Focus();
                 return false;
             }

--- a/Visualizer/OperationDataProcessor.cs
+++ b/Visualizer/OperationDataProcessor.cs
@@ -15,7 +15,6 @@ using System.Data;
 using System.Globalization;
 using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
-using AgGateway.ADAPT.ApplicationDataModel.Shapes;
 
 using Point = AgGateway.ADAPT.ApplicationDataModel.Shapes.Point;
 
@@ -129,12 +128,12 @@ namespace AgGateway.ADAPT.Visualizer
             }
 
             dataRow["Index"] = index;
-            if (spatialRecord.Geometry != null)
+            if (spatialRecord.Geometry is Point ptData)
             {
                 //Fill in the other cells
-                dataRow["Latitude"] = (spatialRecord.Geometry as Point).Y.ToString(); //Y
-                dataRow["Longitude"] = (spatialRecord.Geometry as Point).X.ToString(); //X
-                dataRow["Elevation"] = (spatialRecord.Geometry as Point).Z.ToString(); //Z
+                dataRow["Latitude"] = ptData.Y.ToString(); //Y
+                dataRow["Longitude"] = ptData.X.ToString(); //X
+                dataRow["Elevation"] = ptData.Z.ToString(); //Z
             }
             if (spatialRecord.Timestamp != null)
             {
@@ -173,7 +172,7 @@ namespace AgGateway.ADAPT.Visualizer
                     var uoms = numericRepresentationValues.Select(x => x.Value.UnitOfMeasure).ToList();
                 
                     if (uoms.Any())
-                        _dataTable.Columns[GetColumnName(data, kvp.Key)].ColumnName += "-" + uoms.First().Code;
+                        _dataTable.Columns[GetColumnName(data, kvp.Key)].ColumnName += "-" + uoms.First()?.Code;
                 }
             }
         }

--- a/Visualizer/PointExtension.cs
+++ b/Visualizer/PointExtension.cs
@@ -9,12 +9,11 @@
  *    Tarak Reddy - initial implementation
  *******************************************************************************/
 
-using System;
-using System.Drawing;
+using AgGateway.ADAPT.ApplicationDataModel.Shapes;
 
 namespace AgGateway.ADAPT.Visualizer
 {
-   public static class PointExtension
+    public static class PointExtension
     {
         private const double ConstDeg2Rad = 0.0174532925;
         private const double A = 6378137;
@@ -62,6 +61,34 @@ namespace AgGateway.ADAPT.Visualizer
             var y = (point.Y - minY)/delta+25;
              
             return new PointF((float)x, (float)y);
+        }
+
+        public static ApplicationDataModel.Shapes.Point? FirstPoint(this ApplicationDataModel.Shapes.Shape geometry)
+        {
+            if (geometry is null)
+            {
+                return null;
+            }
+            switch (geometry.Type)
+            {
+                case ShapeTypeEnum.LineString:
+                    return ((LineString)geometry).Points[0];
+                case ShapeTypeEnum.LinearRing:
+                    return ((LinearRing)geometry).Points[0];
+                case ShapeTypeEnum.MultiLineString:
+                    return ((MultiLineString)geometry).LineStrings[0].Points[0];
+                case ShapeTypeEnum.MultiPoint:
+                    return ((MultiPoint)geometry).Points[0];
+                case ShapeTypeEnum.MultiPolygon:
+                    return ((MultiPolygon)geometry).Polygons[0].ExteriorRing.Points[0];
+                case ShapeTypeEnum.Point:
+                    return (ApplicationDataModel.Shapes.Point)geometry;
+                    break;
+                case ShapeTypeEnum.Polygon:
+                    return ((Polygon)geometry).ExteriorRing.Points[0];
+                default:
+                    return null;
+            }
         }
 
         private static double GetLongOrigin(double lon)

--- a/Visualizer/SpatialRecordProcessor.cs
+++ b/Visualizer/SpatialRecordProcessor.cs
@@ -11,9 +11,9 @@
   *******************************************************************************/
 
 using System.Drawing.Imaging;
-using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
-using AgGateway.ADAPT.ApplicationDataModel.Equipment;
 using AgGateway.ADAPT.ApplicationDataModel.ADM;
+using AgGateway.ADAPT.ApplicationDataModel.Equipment;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
 using Point = AgGateway.ADAPT.ApplicationDataModel.Shapes.Point;
 
@@ -63,7 +63,12 @@ namespace AgGateway.ADAPT.Visualizer
                 List<double> doubleValues = null;
                 foreach (SpatialRecord record in _spatialRecords)
                 {
-                    Point point = record.Geometry as Point;
+                    Point? point = record.Geometry.FirstPoint();
+                    if (point is null)
+                    {
+                        continue;
+                    }
+
                     projectedPoints.Add(point.ToUtm());
 
                     if (_workingDataDictionary.ContainsKey(workingDataKey))


### PR DESCRIPTION
Don't crash on Trimble data, where the spatial record geometries aren't points.  Also, don't crash when an initialization string is specified and there are multiple plugins in the plugin directory that take different initialization strings