### PR TITLE
Fix a cross-thread crash I introduced in a previous pull request

### DIFF
--- a/Visualizer/Model.cs
+++ b/Visualizer/Model.cs
@@ -279,7 +279,7 @@ namespace AgGateway.ADAPT.Visualizer
                 ApplicationDataModels = _dataProvider.Import(datacardPath, initializeString, properties);
                 if (ApplicationDataModels == null || ApplicationDataModels.Count == 0)
                 {
-                    MessageBox.Show(TreeViewForm, @"Not supported data format.");
+                    ShowMessageBox(@"Not supported data format.");
                     CurrentState = State.StateIdle;
                     _updateStatusAction(CurrentState, "Done");
                     return;


### PR DESCRIPTION
Fixed a cross-thread crash I accidentally introduced by adding TreeViewForm to the MessageBox.Show call on a background thread.  I've audited other uses and this looks like the only one that wasn't properly invoked.