### PR TITLE
Fix UTM discontinuity across zones and hemispheres (#41)

### DIFF
--- a/Visualizer/ShapeExtensions.cs
+++ b/Visualizer/ShapeExtensions.cs
@@ -24,10 +24,25 @@ namespace AgGateway.ADAPT.Visualizer
 
         public static ApplicationDataModel.Shapes.Point ToUtm(this ApplicationDataModel.Shapes.Point point)
         {
+            return ProjectToUtm(point, GetLongOrigin(point.X), point.Y < 0);
+        }
+
+        public static ApplicationDataModel.Shapes.Point ToUtmRelativeToSpatialRecordFirstPoint(
+            this ApplicationDataModel.Shapes.Point point,
+            ApplicationDataModel.Shapes.Point firstPoint)
+        {
+            return ProjectToUtm(point, GetLongOrigin(firstPoint.X), firstPoint.Y < 0);
+        }
+
+        private static ApplicationDataModel.Shapes.Point ProjectToUtm(
+            ApplicationDataModel.Shapes.Point point,
+            double longitudeOriginDegrees,
+            bool applySouthernHemisphereOffset)
+        {
             var latitudeInRadians = point.Y * ConstDeg2Rad;
             var longitudeInRadians = point.X * ConstDeg2Rad;
 
-            var longitudeOriginInRadians = GetLongOrigin(point.X) * ConstDeg2Rad;
+            var longitudeOriginInRadians = longitudeOriginDegrees * ConstDeg2Rad;
 
             var n = A / Math.Sqrt(1 - EccSquared * Math.Sin(latitudeInRadians) * Math.Sin(latitudeInRadians));
             var t = Math.Tan(latitudeInRadians) * Math.Tan(latitudeInRadians);
@@ -48,7 +63,7 @@ namespace AgGateway.ADAPT.Visualizer
                                                           (61 - 58 * t + t * t + 600 * c - 330 * EccPrimeSquared) * a1 * a1 * a1 * a1 *
                                                           a1 * a1 / 720));
 
-            if (point.Y < 0)
+            if (applySouthernHemisphereOffset)
             {
                 utmNorthing += 10000000.0;
             }

--- a/Visualizer/SpatialRecordProcessor.cs
+++ b/Visualizer/SpatialRecordProcessor.cs
@@ -58,6 +58,7 @@ namespace AgGateway.ADAPT.Visualizer
 
             List<Point> projectedPoints = new List<Point>();
             List<double> doubleValues = null;
+            Point? firstPoint = null;
             foreach (SpatialRecord record in _spatialRecords)
             {
                 Point? point = record.Geometry.FirstPoint();
@@ -66,7 +67,12 @@ namespace AgGateway.ADAPT.Visualizer
                     continue;
                 }
 
-                projectedPoints.Add(point.ToUtm());
+                if (firstPoint == null)
+                {
+                    firstPoint = point;
+                }
+
+                projectedPoints.Add(point.ToUtmRelativeToSpatialRecordFirstPoint(firstPoint));
 
                 if (_workingDataDictionary.ContainsKey(workingDataKey))
                 {


### PR DESCRIPTION
Related issue: https://github.com/ADAPT/ADAPT-Visualizer/issues/41

The change preserves backward compatibility by keeping the original ToUtm() method untouched and adding a new one. Other parts of the project that use ToUtm might need a review.